### PR TITLE
Fixed use of obsolete symbols in Unity versions >= 2020.1

### DIFF
--- a/Assets/_PackageRoot/Runtime/ImageLoader.cs
+++ b/Assets/_PackageRoot/Runtime/ImageLoader.cs
@@ -157,10 +157,20 @@ namespace Extensions.Unity.ImageLoader
 
             RemoveLoading(url);
 
-            if (request.isNetworkError || request.isHttpError)
+#if UNITY_2020_1_OR_NEWER
+            var isError = request.result != UnityWebRequest.Result.Success;
+#else
+            var isError = request.isNetworkError || request.isHttpError;
+#endif
+
+            if (isError)
             {
                 if (settings.debugLevel <= DebugLevel.Error)
+#if UNITY_2020_1_OR_NEWER
+                    Debug.LogError($"[ImageLoader] {request.result} {request.error}: url={url}");
+#else
                     Debug.LogError($"[ImageLoader] {request.error}: url={url}");
+#endif
                 return null;
             }
             else


### PR DESCRIPTION
The package has some warnings on Unity versions from 2020.1 and up, as the obsoleted properties UnityWebRequest.isNetworkError and .isHttpError are used. This replaces those with checking if request.result != UnityWebRequest.Result.Success on versions >= 2020.1. 

I've kept the support for 2019.2 (the oldest version supported according to the package.json) by checking for the version. 