### PR TITLE
Added support for fast enter play mode (no domain reload)

### DIFF
--- a/Assets/_PackageRoot/Runtime/ImageLoader.MemoryCache.cs
+++ b/Assets/_PackageRoot/Runtime/ImageLoader.MemoryCache.cs
@@ -10,8 +10,8 @@ namespace Extensions.Unity.ImageLoader
         private static void ClearMemoryCacheOnEnterPlayMode()
         {
             // Support for turning off domain reload in Project Settings/Editor/Enter Play Mode Settings
-            // Sprites created with Sprite.Create gets destroyed when exiting and entering play mode, even if the domain does not get reloaded.
-            // So we need to clear the sprite cache, as otherwise the cache will be filled with keys pointing at destroyed Sprites.
+            // Sprites created with Sprite.Create gets destroyed when exiting play mode, so we need to clear the sprite cache, as otherwise the cache will be
+            // filled with destroyed sprites when the user reenters play mode.
             memorySpriteCache.Clear();
         }
 #endif

--- a/Assets/_PackageRoot/Runtime/ImageLoader.MemoryCache.cs
+++ b/Assets/_PackageRoot/Runtime/ImageLoader.MemoryCache.cs
@@ -5,6 +5,17 @@ namespace Extensions.Unity.ImageLoader
 {
     public static partial class ImageLoader
     {
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnEnterPlayMode]
+        private static void ClearMemoryCacheOnEnterPlayMode()
+        {
+            // Support for turning off domain reload in Project Settings/Editor/Enter Play Mode Settings
+            // Sprites created with Sprite.Create gets destroyed when exiting and entering play mode, even if the domain does not get reloaded.
+            // So we need to clear the sprite cache, as otherwise the cache will be filled with keys pointing at destroyed Sprites.
+            memorySpriteCache.Clear();
+        }
+#endif
+
         internal static Dictionary<string, Sprite> memorySpriteCache = new Dictionary<string, Sprite>();
 
         /// <summary>


### PR DESCRIPTION
This adds (partial) support for turning off domain reloads to the memory cache.

When domain reloads are turned off in the Edit/Project Settings/Editor, `ImageLoader.memorySpriteCache` will survive exiting and then entering play mode. But sprites created with Sprite.Create (like the sprites created by ImageLoader) in play mode will always get destroyed as you exit play mode, leading to destroyed images surviving in the memory cache.

The fix is to simply clear the memory cache in a method marked with [UnityEditor.InitializeOnEnterPlayMode]. This makes sure that images are cleared properly.

I'm saying that this adds partial support, because I'm not trying to handle what happens with images that are currently in the process of getting loaded on some thread if you start a load, and then quickly exit and enter play mode again. That would probably require some kind of cancellation token setup, and I'm not familiar enough with all the possible caveats, and I think it's a small enough problem that I won't fix it.