### PR TITLE
fix: NullReferenceException in RemoveLoading (#39) + bump to 7.0.3

### DIFF
--- a/Installer/Assets/com.IvanMurzak/Image Loader Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/Image Loader Installer/Installer.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.ImageLoader.Installer
     public static partial class Installer
     {
         public const string PackageId = "extensions.unity.imageloader";
-        public const string Version = "7.0.2";
+        public const string Version = "7.0.3";
 
         static Installer()
         {

--- a/Unity-Package/Assets/root/Runtime/Future/Future.Loading.List.cs
+++ b/Unity-Package/Assets/root/Runtime/Future/Future.Loading.List.cs
@@ -38,7 +38,7 @@ namespace Extensions.Unity.ImageLoader
                 else
                 {
                     if (ImageLoader.settings.debugLevel.IsActive(DebugLevel.Warning))
-                        Debug.LogWarning($"[ImageLoader] Future[id={future.Id}] Wasn't able to remove loading registration, not found in loading tasks\n{url}");
+                        Debug.LogWarning($"[ImageLoader] Wasn't able to remove loading registration, not found in loading tasks\n{url}");
                 }
             }
         }

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/IvanMurzak"
   },
   "license": "MIT",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "unity": "2019.4",
   "description": "Asynchronous image loading from remote or local destination. It has two layers of configurable Memory and Disk cache systems.",
   "keywords": [


### PR DESCRIPTION
## Summary

Fixes the `NullReferenceException` reported in #39 and bumps the package to **7.0.3**.

## Root cause

In `Future.Loading.List.cs`, `RemoveLoading(string url)` calls `loadingInProcess.TryRemove(url, out var future)`. When `TryRemove` returns `false` (the entry is not present — e.g. it was already removed by a concurrent completion/cancellation), the `out` variable `future` is `null`. The `else` (warning) branch then logged `Future[id={future.Id}]`, dereferencing the null `future` and throwing `NullReferenceException`.

## Fix

In the warning branch, log using the in-scope `url` only, without dereferencing the null `future`:

```diff
- Debug.LogWarning($"[ImageLoader] Future[id={future.Id}] Wasn't able to remove loading registration, not found in loading tasks\n{url}");
+ Debug.LogWarning($"[ImageLoader] Wasn't able to remove loading registration, not found in loading tasks\n{url}");
```

The `DebugLevel.Warning` guard, indentation, and code style are preserved. The success branch (where `future` is non-null) is unchanged.

## Review outcome

Ran a high-effort code review over the diff. No additional non-minor findings:
- The surrounding `lock (loadingInProcess)` shared between `RegisterLoading`/`RemoveLoading` makes the check-then-act atomic and consistent; locking is sound.
- The only other deref of an `out` from a failed lookup — `anotherLoadingFuture` at the `RegisterLoading` call site — is only used on the path where the value was set by a successful `TryGetValue` (non-null), so it is safe.
- No other `TryRemove`/`TryGetValue` null-deref sites exist in the file or its immediate call sites.

## Version bump

Ran `bump-version.ps1 -NewVersion 7.0.3`, which updated `package.json` and the Installer.cs `Version` constant (README was already dropped from the bump targets upstream).

Fixes #39