### PR TITLE
test: de-flake TestFutureWaitingAnotherFuture cancel-while-loading

### DIFF
--- a/Unity-Package/Assets/root/Tests/Base/Utils/MockWebRequestProvider.cs
+++ b/Unity-Package/Assets/root/Tests/Base/Utils/MockWebRequestProvider.cs
@@ -24,10 +24,29 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         }
 
         readonly Dictionary<string, string> successUrlToImageId = new Dictionary<string, string>();
+        // URLs routed to the deterministically held route. The request reaches the
+        // server and stays in-flight until the test releases the matching id, which is
+        // what makes "cancel-while-loading" scenarios deterministic.
+        readonly Dictionary<string, string> heldUrlToImageId = new Dictionary<string, string>();
 
-        public void Reset() => successUrlToImageId.Clear();
+        public void Reset()
+        {
+            successUrlToImageId.Clear();
+            heldUrlToImageId.Clear();
+        }
 
         public void RegisterSuccess(string url, string imageId) => successUrlToImageId[url] = imageId;
+
+        /// <summary>
+        /// Routes <paramref name="url"/> to the server's held route (<c>/hold/{imageId}</c>).
+        /// The server must have the id armed via <see cref="TestHttpServer.HoldImage"/> and
+        /// the test must release it via <see cref="TestHttpServer.ReleaseHeld"/>. While held,
+        /// a load of this URL stays in the LoadingFromSource state. Call <see cref="UnregisterHeld"/>
+        /// (or <see cref="Reset"/>) to restore the normal fast/slow routing.
+        /// </summary>
+        public void RegisterHeld(string url, string imageId) => heldUrlToImageId[url] = imageId;
+
+        public void UnregisterHeld(string url) => heldUrlToImageId.Remove(url);
 
         public UnityWebRequest CreateTextureRequest(string url)
             => UnityWebRequestTexture.GetTexture(ResolveUrl(url));
@@ -38,6 +57,8 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         string ResolveUrl(string url)
         {
             var baseUrl = TestHttpServer.Instance.BaseUrl;
+            if (heldUrlToImageId.TryGetValue(url, out var heldId))
+                return $"{baseUrl}/hold/{heldId}";
             return successUrlToImageId.TryGetValue(url, out var id)
                 ? $"{baseUrl}/img/{id}"
                 : $"{baseUrl}/slow";

--- a/Unity-Package/Assets/root/Tests/Base/Utils/TestHttpServer.cs
+++ b/Unity-Package/Assets/root/Tests/Base/Utils/TestHttpServer.cs
@@ -9,12 +9,22 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
 {
     /// <summary>
     /// Minimal in-process HTTP server bound to 127.0.0.1 for deterministic, offline
-    /// image-loading tests. Serves pre-generated PNG bytes for success routes and a
-    /// deliberately slow route so the client-side Future timeout fires predictably.
+    /// image-loading tests. Serves pre-generated PNG bytes for success routes, a
+    /// deliberately slow route so the client-side Future timeout fires predictably,
+    /// and a deterministically *held* route whose response is blocked until the test
+    /// explicitly releases it.
     ///
     /// This replaces the public image URLs the tests used to fetch from GitHub, which
     /// were rate-limited and unreliable on CI, while keeping the loader's real
     /// UnityWebRequest send/decode path intact.
+    ///
+    /// The held route (<c>/hold/{id}</c>) exists to make "cancel-while-loading"
+    /// scenarios deterministic: the request reaches the server, the server begins a
+    /// response but parks the worker thread on a per-id gate, so the client-side
+    /// Future is guaranteed to be in the <c>LoadingFromSource</c> state (still
+    /// in-flight, not yet memory-cached) until the test calls <see cref="ReleaseHeld"/>.
+    /// This removes the timing race where a fast local load could complete before the
+    /// test got a chance to cancel it.
     /// </summary>
     public sealed class TestHttpServer
     {
@@ -30,6 +40,10 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
 
         readonly object gate = new object();
         readonly Dictionary<string, byte[]> images = new Dictionary<string, byte[]>();
+        // Per-id gates for the /hold/{id} route. A held request parks on its event
+        // until the test releases it (or Stop() releases everything). Created lazily
+        // by HoldImage so a held route always serves a valid, registered image.
+        readonly Dictionary<string, ManualResetEventSlim> holdGates = new Dictionary<string, ManualResetEventSlim>();
         TcpListener listener;
         Thread acceptThread;
         volatile bool running;
@@ -63,6 +77,47 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
             lock (gate) images[id] = pngBytes;
         }
 
+        /// <summary>
+        /// Arms the held gate for <paramref name="id"/>. After this call any request to
+        /// <c>/hold/{id}</c> blocks (the connection stays open, response withheld) until
+        /// <see cref="ReleaseHeld"/> is called for the same id. Idempotent: re-holding an
+        /// already-armed id re-blocks it. The id must also be registered via
+        /// <see cref="RegisterImage"/> so a valid image is served once released.
+        /// </summary>
+        public void HoldImage(string id)
+        {
+            lock (gate)
+            {
+                if (holdGates.TryGetValue(id, out var existing))
+                    existing.Reset();
+                else
+                    holdGates[id] = new ManualResetEventSlim(initialState: false);
+            }
+        }
+
+        /// <summary>
+        /// Releases a previously held id, letting its parked request(s) send the image
+        /// and complete. Safe to call when nothing is held (no-op).
+        /// </summary>
+        public void ReleaseHeld(string id)
+        {
+            ManualResetEventSlim ev;
+            lock (gate) holdGates.TryGetValue(id, out ev);
+            ev?.Set();
+        }
+
+        /// <summary>
+        /// Releases every held id. Used by <see cref="Stop"/> and as a safety net in
+        /// test teardown so no worker thread is left parked.
+        /// </summary>
+        public void ReleaseAllHeld()
+        {
+            List<ManualResetEventSlim> all;
+            lock (gate) all = new List<ManualResetEventSlim>(holdGates.Values);
+            foreach (var ev in all)
+                ev.Set();
+        }
+
         public void Stop()
         {
             lock (gate)
@@ -72,6 +127,8 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
                 try { listener?.Stop(); } catch { /* already stopped */ }
                 listener = null;
             }
+            // Unblock any parked /hold workers so they exit cleanly and threads don't leak.
+            ReleaseAllHeld();
         }
 
         void AcceptLoop()
@@ -104,7 +161,33 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
                     {
                         // Hold the response so the client-side timeout fires first.
                         Thread.Sleep(SlowDelay);
-                        TryWrite(stream, BuildResponse(200, "OK", "text/plain", Encoding.ASCII.GetBytes("slow")));
+                        WriteAndClose(client, stream, BuildResponse(200, "OK", "text/plain", Encoding.ASCII.GetBytes("slow")));
+                        return;
+                    }
+
+                    if (path.StartsWith("/hold/"))
+                    {
+                        var id = path.Substring("/hold/".Length);
+                        ManualResetEventSlim ev;
+                        byte[] png;
+                        bool found;
+                        lock (gate)
+                        {
+                            holdGates.TryGetValue(id, out ev);
+                            found = images.TryGetValue(id, out png);
+                        }
+                        // Park the worker until the test releases this id (or Stop()
+                        // releases everything). The client request is fully sent and the
+                        // connection is open, so the client-side Future is guaranteed to
+                        // be in the LoadingFromSource state for the whole wait.
+                        ev?.Wait();
+                        if (found && running)
+                        {
+                            WriteAndClose(client, stream, BuildResponse(200, "OK", "image/png", png));
+                            return;
+                        }
+                        // Released by Stop() (server shutting down) or id not registered:
+                        // just drop the connection so the client errors out cleanly.
                         return;
                     }
 
@@ -116,12 +199,12 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
                         lock (gate) found = images.TryGetValue(id, out png);
                         if (found)
                         {
-                            TryWrite(stream, BuildResponse(200, "OK", "image/png", png));
+                            WriteAndClose(client, stream, BuildResponse(200, "OK", "image/png", png));
                             return;
                         }
                     }
 
-                    TryWrite(stream, BuildResponse(404, "Not Found", "text/plain", Encoding.ASCII.GetBytes("not found")));
+                    WriteAndClose(client, stream, BuildResponse(404, "Not Found", "text/plain", Encoding.ASCII.GetBytes("not found")));
                 }
             }
             catch { /* client aborted or disconnected — expected for slow/timeout tests */ }
@@ -153,9 +236,54 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
             return response;
         }
 
-        static void TryWrite(NetworkStream stream, byte[] data)
+        // Writes the full response, then closes the connection *gracefully* to avoid a
+        // TCP RST. The original implementation wrote the bytes and let `using` dispose
+        // the socket immediately; on Windows, closing a socket while the peer's request
+        // bytes (headers/body) are still sitting unread in the receive buffer makes the
+        // OS send an RST instead of a FIN. curl then reports "Curl error 56: Recv
+        // failure: Connection was reset" at random, which surfaced as a flaky
+        // "Failed to receive data" test failure. The fix: drain the rest of the request,
+        // half-close our send side (sends FIN), then wait for the peer's FIN before
+        // disposing. This is the textbook lingering-close handshake.
+        static void WriteAndClose(TcpClient client, NetworkStream stream, byte[] data)
         {
-            try { stream.Write(data, 0, data.Length); stream.Flush(); } catch { /* client gone */ }
+            try
+            {
+                stream.Write(data, 0, data.Length);
+                stream.Flush();
+
+                var socket = client.Client;
+                // Drain whatever the client already sent (the rest of the HTTP request)
+                // so there is no unread inbound data when we close.
+                DrainAvailable(socket);
+                // Send FIN on our side; the client reads EOF and closes its side.
+                try { socket.Shutdown(SocketShutdown.Send); } catch { /* already closed */ }
+                // Wait for the client's FIN (ReadByte returns -1) so the close is fully
+                // graceful before the socket is disposed. Bounded so we never hang.
+                WaitForPeerClose(stream);
+            }
+            catch { /* client gone */ }
+        }
+
+        static void DrainAvailable(Socket socket)
+        {
+            try
+            {
+                var buffer = new byte[1024];
+                while (socket.Available > 0 && socket.Receive(buffer, 0, buffer.Length, SocketFlags.None) > 0) { }
+            }
+            catch { /* nothing more to drain */ }
+        }
+
+        static void WaitForPeerClose(NetworkStream stream)
+        {
+            try
+            {
+                stream.ReadTimeout = 2000;
+                int b;
+                do { b = stream.ReadByte(); } while (b != -1);
+            }
+            catch { /* timeout or reset — close anyway */ }
         }
     }
 }

--- a/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.Load.cs
+++ b/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.Load.cs
@@ -19,8 +19,26 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         // missing — a timing flake (seen on fast CI runners). Creating the future
         // un-started, attaching the listener, registering the placeholders, and only then
         // calling StartLoading() makes the loading-placeholder consume deterministic.
+        //
+        // cancelAtLoadingFrom makes "cancel-while-loading-from-disk-cache" deterministic.
+        // The disk read is a local File.ReadAllBytes dispatched to a TaskFactory; on a
+        // fast machine that Task can complete (and the awaiting continuation resume
+        // inline) entirely inside StartLoading(), so the future reaches
+        // LoadedFromDiskCache before the test's post-StartLoading Cancel() runs — the
+        // test then sees a successful load instead of the cancel (observed once on a
+        // windows-mono standalone leg). To cancel reliably *while in the loading state*
+        // we hook the cancel to the last synchronous loading-state callback so the
+        // event order is preserved exactly:
+        //   - usePlaceholder == false: cancel from the LoadingFrom... event (no consume
+        //     happens), yielding LoadingFrom..., Canceled, Completed.
+        //   - usePlaceholder == true: cancel from the loading-placeholder Consume, which
+        //     runs after the listener has recorded the loading event and its Consume,
+        //     yielding LoadingFrom..., Consumed, Canceled, Consumed, Completed.
+        // The runtime re-checks IsCancelled after the disk read (Future.Loading.cs), so a
+        // cancel raised here reliably wins over the read result.
         static FutureListener<UnityEngine.Sprite> StartLoadSpriteWithPlaceholders(
-            string url, bool usePlaceholder, bool ignoreLoadingWhenLoaded, out FutureSprite future)
+            string url, bool usePlaceholder, bool ignoreLoadingWhenLoaded, out FutureSprite future,
+            FutureLoadingFrom? cancelAtLoadingFrom = null)
         {
             future = new FutureSprite(url);
             var listener = future.ToFutureListener(ignoreLoadingWhenLoaded: ignoreLoadingWhenLoaded, ignorePlaceholder: !usePlaceholder);
@@ -31,6 +49,42 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
                 future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.LoadingFromSource], PlaceholderTrigger.LoadingFromSource);
                 future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.FailedToLoad], PlaceholderTrigger.FailedToLoad);
                 future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.Canceled], PlaceholderTrigger.Canceled);
+            }
+
+            if (cancelAtLoadingFrom.HasValue)
+            {
+                var self = future;
+                var loadingPlaceholderStatus = cancelAtLoadingFrom.Value == FutureLoadingFrom.Source
+                    ? FutureStatus.LoadingFromSource
+                    : FutureStatus.LoadingFromDiskCache;
+                var armed = true;
+                if (usePlaceholder)
+                {
+                    // Cancel from the loading-placeholder consume (runs after the loading
+                    // event + its consume have been recorded, while still in the loading
+                    // state) so the consume/cancel order matches the expected sequence.
+                    future.Consume(value =>
+                    {
+                        if (armed && self.Status == loadingPlaceholderStatus)
+                        {
+                            armed = false;
+                            self.Cancel();
+                        }
+                    });
+                }
+                else
+                {
+                    void CancelOnce()
+                    {
+                        if (!armed) return;
+                        armed = false;
+                        self.Cancel();
+                    }
+                    if (cancelAtLoadingFrom.Value == FutureLoadingFrom.Source)
+                        future.LoadingFromSource(CancelOnce);
+                    else
+                        future.LoadingFromDiskCache(CancelOnce);
+                }
             }
 
             future.StartLoading();
@@ -153,7 +207,16 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         }
         public static IEnumerator LoadAndCancel(string url, FutureLoadingFrom? expectedLoadingFrom, bool useGC, bool usePlaceholder = false)
         {
-            var futureListener = StartLoadSpriteWithPlaceholders(url, usePlaceholder, ignoreLoadingWhenLoaded: false, out var future);
+            // For a load from disk cache the read can complete synchronously inside
+            // StartLoading() and beat the explicit Cancel() below, so cancel at the
+            // loading transition instead (see StartLoadSpriteWithPlaceholders). The
+            // explicit Cancel() further down then becomes a harmless no-op. Source loads
+            // go through UnityWebRequest (never synchronous) and memory-cache loads are
+            // not a cancel-while-loading scenario, so neither needs this.
+            var cancelAtLoadingFrom = expectedLoadingFrom.HasValue && expectedLoadingFrom.Value == FutureLoadingFrom.DiskCache
+                ? expectedLoadingFrom
+                : null;
+            var futureListener = StartLoadSpriteWithPlaceholders(url, usePlaceholder, ignoreLoadingWhenLoaded: false, out var future, cancelAtLoadingFrom);
             var shouldLoadFromMemoryCache = !expectedLoadingFrom.HasValue;
 
             futureListener.Assert_Events_Contains(expectedLoadingFrom.HasValue

--- a/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.Load.cs
+++ b/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.Load.cs
@@ -8,11 +8,22 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
 {
     public static partial class TestUtils
     {
-        public static IEnumerator LoadFromMemoryCache(string url, bool usePlaceholder = false) => Load(url, null, FutureLoadedFrom.MemoryCache, usePlaceholder);
-        public static IEnumerator Load(string url, FutureLoadingFrom? expectedLoadingFrom, FutureLoadedFrom expectedLoadedFrom, bool usePlaceholder = false)
+        // Starts loading a sprite while guaranteeing that, when usePlaceholder is set,
+        // the loading-state placeholders are registered BEFORE the load can advance past
+        // the loading state.
+        //
+        // ImageLoader.LoadSprite(url) starts the load synchronously inside the call, so a
+        // fast (disk/memory-cache) load can reach LoadedFrom* before the test gets a
+        // chance to call SetPlaceholder afterwards. When that happens the loading-state
+        // placeholder is never consumed and the expected first "Consumed" event is
+        // missing — a timing flake (seen on fast CI runners). Creating the future
+        // un-started, attaching the listener, registering the placeholders, and only then
+        // calling StartLoading() makes the loading-placeholder consume deterministic.
+        static FutureListener<UnityEngine.Sprite> StartLoadSpriteWithPlaceholders(
+            string url, bool usePlaceholder, bool ignoreLoadingWhenLoaded, out FutureSprite future)
         {
-            var future = ImageLoader.LoadSprite(url);
-            var futureListener = future.ToFutureListener(ignorePlaceholder: !usePlaceholder);
+            future = new FutureSprite(url);
+            var listener = future.ToFutureListener(ignoreLoadingWhenLoaded: ignoreLoadingWhenLoaded, ignorePlaceholder: !usePlaceholder);
 
             if (usePlaceholder)
             {
@@ -21,6 +32,15 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
                 future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.FailedToLoad], PlaceholderTrigger.FailedToLoad);
                 future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.Canceled], PlaceholderTrigger.Canceled);
             }
+
+            future.StartLoading();
+            return listener;
+        }
+
+        public static IEnumerator LoadFromMemoryCache(string url, bool usePlaceholder = false) => Load(url, null, FutureLoadedFrom.MemoryCache, usePlaceholder);
+        public static IEnumerator Load(string url, FutureLoadingFrom? expectedLoadingFrom, FutureLoadedFrom expectedLoadedFrom, bool usePlaceholder = false)
+        {
+            var futureListener = StartLoadSpriteWithPlaceholders(url, usePlaceholder, ignoreLoadingWhenLoaded: false, out var future);
 
             if (expectedLoadingFrom.HasValue)
                 futureListener.Assert_Events_Contains(expectedLoadingFrom.Value.ToEventName());
@@ -72,16 +92,7 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
             => LoadThenCancel(url, null, FutureLoadedFrom.MemoryCache, useGC, usePlaceholder);
         public static IEnumerator LoadThenCancel(string url, FutureLoadingFrom? expectedLoadingFrom, FutureLoadedFrom expectedLoadedFrom, bool useGC, bool usePlaceholder = false)
         {
-            var future = ImageLoader.LoadSprite(url);
-            var futureListener = future.ToFutureListener(ignorePlaceholder: !usePlaceholder);
-
-            if (usePlaceholder)
-            {
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.LoadingFromDiskCache], PlaceholderTrigger.LoadingFromDiskCache);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.LoadingFromSource], PlaceholderTrigger.LoadingFromSource);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.FailedToLoad], PlaceholderTrigger.FailedToLoad);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.Canceled], PlaceholderTrigger.Canceled);
-            }
+            var futureListener = StartLoadSpriteWithPlaceholders(url, usePlaceholder, ignoreLoadingWhenLoaded: false, out var future);
 
             if (expectedLoadingFrom.HasValue)
                 futureListener.Assert_Events_Contains(expectedLoadingFrom.Value.ToEventName());
@@ -142,17 +153,8 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         }
         public static IEnumerator LoadAndCancel(string url, FutureLoadingFrom? expectedLoadingFrom, bool useGC, bool usePlaceholder = false)
         {
-            var future = ImageLoader.LoadSprite(url);
-            var futureListener = future.ToFutureListener(ignorePlaceholder: !usePlaceholder);
+            var futureListener = StartLoadSpriteWithPlaceholders(url, usePlaceholder, ignoreLoadingWhenLoaded: false, out var future);
             var shouldLoadFromMemoryCache = !expectedLoadingFrom.HasValue;
-
-            if (usePlaceholder)
-            {
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.LoadingFromDiskCache], PlaceholderTrigger.LoadingFromDiskCache);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.LoadingFromSource], PlaceholderTrigger.LoadingFromSource);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.FailedToLoad], PlaceholderTrigger.FailedToLoad);
-                future.SetPlaceholder(placeholderSprites[PlaceholderTrigger.Canceled], PlaceholderTrigger.Canceled);
-            }
 
             futureListener.Assert_Events_Contains(expectedLoadingFrom.HasValue
                 ? expectedLoadingFrom.Value.ToEventName()

--- a/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.cs
+++ b/Unity-Package/Assets/root/Tests/Base/Utils/TestUtils.cs
@@ -116,6 +116,9 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         public static void EnableMockProvider()
         {
             TestHttpServer.Instance.EnsureStarted();
+            // Safety net: release any gate left armed by a previous (possibly failed)
+            // test so no server worker stays parked across tests.
+            TestHttpServer.Instance.ReleaseAllHeld();
 
             if (mockPngCache == null)
             {
@@ -140,6 +143,43 @@ namespace Extensions.Unity.ImageLoader.Tests.Utils
         public static void DisableMockProvider()
         {
             ImageLoader.settings.webRequestProvider = new DefaultWebRequestProvider();
+        }
+
+        // Maps a registered image URL to its server-side image id (the index used by
+        // EnableMockProvider). Mirrors the registration in EnableMockProvider.
+        static string ImageIdForUrl(string url)
+        {
+            for (int i = 0; i < ImageURLs.Length; i++)
+                if (ImageURLs[i] == url)
+                    return i.ToString();
+            throw new ArgumentException($"URL is not a registered test image: {url}", nameof(url));
+        }
+
+        /// <summary>
+        /// Makes loading <paramref name="url"/> deterministically *hold* in-flight: the
+        /// request reaches the in-process server and parks there, so any Future loading
+        /// this URL stays in the LoadingFromSource state until <see cref="ReleaseHeld"/>
+        /// is called. This replaces racing the clock to catch a fast local load while it
+        /// is still running. Must be paired with <see cref="ReleaseHeld"/>.
+        /// </summary>
+        public static void BeginHold(string url)
+        {
+            var id = ImageIdForUrl(url);
+            TestHttpServer.Instance.EnsureStarted();
+            TestHttpServer.Instance.HoldImage(id);
+            MockWebRequestProvider.Instance.RegisterHeld(url, id);
+        }
+
+        /// <summary>
+        /// Releases a hold started by <see cref="BeginHold"/>: the parked server response
+        /// is sent and the URL is routed back to the normal fast route. Safe to call even
+        /// if nothing is held.
+        /// </summary>
+        public static void ReleaseHeld(string url)
+        {
+            var id = ImageIdForUrl(url);
+            TestHttpServer.Instance.ReleaseHeld(id);
+            MockWebRequestProvider.Instance.UnregisterHeld(url);
         }
     }
 }

--- a/Unity-Package/Assets/root/Tests/Editor/TestFutureWaitingAnotherFuture.Load.AndCancel.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/TestFutureWaitingAnotherFuture.Load.AndCancel.cs
@@ -23,8 +23,16 @@ namespace Extensions.Unity.ImageLoader.Tests
 
             foreach (var url in TestUtils.ImageURLs)
             {
+                // Hold the source load in-flight so the outer future stays in the
+                // LoadingFromSource state for the whole LoadAndCancel sequence. Without
+                // this, the fast in-process load can complete and populate the memory
+                // cache before the inner future is cancelled, so the inner future would
+                // observe LoadedFromMemoryCache instead of the LoadingFromSource cancel
+                // path under test — the source of the historical flake.
+                TestUtils.BeginHold(url);
                 var future = ImageLoader.LoadSprite(url);
                 yield return TestUtils.LoadAndCancel(url, FutureLoadingFrom.Source);
+                TestUtils.ReleaseHeld(url);
                 future.Dispose();
             }
 

--- a/Unity-Package/Assets/root/Tests/Runtime/TestFutureWaitingAnotherFuture.Load.AndCancel.cs
+++ b/Unity-Package/Assets/root/Tests/Runtime/TestFutureWaitingAnotherFuture.Load.AndCancel.cs
@@ -23,8 +23,16 @@ namespace Extensions.Unity.ImageLoader.Tests
 
             foreach (var url in TestUtils.ImageURLs)
             {
+                // Hold the source load in-flight so the outer future stays in the
+                // LoadingFromSource state for the whole LoadAndCancel sequence. Without
+                // this, the fast in-process load can complete and populate the memory
+                // cache before the inner future is cancelled, so the inner future would
+                // observe LoadedFromMemoryCache instead of the LoadingFromSource cancel
+                // path under test — the source of the historical flake.
+                TestUtils.BeginHold(url);
                 var future = ImageLoader.LoadSprite(url);
                 yield return TestUtils.LoadAndCancel(url, FutureLoadingFrom.Source);
+                TestUtils.ReleaseHeld(url);
                 future.Dispose();
             }
 


### PR DESCRIPTION
## Problem

Release `7.0.4` (the issue #39 NRE fix + a follow-up warning-log tweak) was committed to `main` but never published: the release matrix keeps going red at random on a pre-existing flaky test in the `TestFutureWaitingAnotherFuture` family — mostly on `windows-mono` legs:

```
System.Exception : Expected event LoadingFromSource, but it was not found.
Got: LoadedFromMemoryCache, Loaded, Completed
```

These are test-harness races. **No runtime/library code is touched** (everything is under `Tests/`).

## Root causes (two of them)

**1. `LoadingFromSource` race (the reported flake).**
`LoadFrom_Source_AndCancel` -> `LoadAndCancel(url, Source)` starts an outer future loading the URL, then attaches an inner future that is supposed to observe `LoadingFromSource` and be cancelled mid-load. The in-process mock server (`TestHttpServer`) answered instantly, so the outer load often *completed and populated the memory cache* before the cancel — the inner future then observed `LoadedFromMemoryCache` instead of `LoadingFromSource`. This was both the flake and a coverage gap (it sometimes cancelled *after* completion, never exercising the mid-load cancel it exists to test).

**2. Connection-reset race (found while reproducing locally).**
`TestHttpServer` wrote the response and let `using` dispose the socket immediately. On Windows, closing a socket while the peer's request bytes are still unread makes the OS send a TCP **RST** instead of FIN, so curl intermittently failed with `Curl error 56: Recv failure: Connection was reset`, surfacing as `Failed to receive data` across many tests in the family. This was actually the dominant local failure on `2019.4.40f1`.

## Fix (determinism, not timing)

- **`TestHttpServer`**: new deterministically *held* route `/hold/{id}` gated by a per-id `ManualResetEventSlim`, with `HoldImage` / `ReleaseHeld` / `ReleaseAllHeld`. A held request reaches the server and parks there, so the client-side Future is guaranteed to stay in `LoadingFromSource` until the test releases it. Held workers are unblocked on `Stop()` so no thread leaks.
- **`TestHttpServer.WriteAndClose`**: replaces the abrupt close with a graceful lingering close (drain request -> half-close send -> wait bounded for peer FIN), eliminating the RST/"Connection was reset" flake for every route.
- **`MockWebRequestProvider`**: `RegisterHeld` / `UnregisterHeld` route chosen URLs to `/hold/{id}`, keeping the existing fast/slow routing for everything else.
- **`TestUtils`**: `BeginHold(url)` / `ReleaseHeld(url)` helpers; `EnableMockProvider` releases any stale gate as a safety net.
- **`TestFutureWaitingAnotherFuture.Load.AndCancel`** (Editor + Runtime, kept in sync): the source cancel test now holds the load in-flight across the whole `LoadAndCancel` sequence, then releases it so the outer load completes and cleans up. **Assertions are unchanged** — the `LoadingFromSource -> Canceled -> Completed` sequence is still asserted; the mid-load cancel is now guaranteed instead of accidental.

## Local evidence

`2019.4.40f1` EditMode, filtered to `TestFutureWaitingAnotherFuture`:

- **Baseline (before fix):** reproduced **9/20 failures** in a single run (both the `LoadingFromSource` flake and the `Connection was reset` flake).
- **After fix:** **10/10 consecutive runs, 20/20 green each.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)